### PR TITLE
Parametric Map Support

### DIFF
--- a/build/dcmjs.js
+++ b/build/dcmjs.js
@@ -50346,7 +50346,7 @@ class Normalizer {
     let toUID = DicomMetaDictionary.sopClassUIDsByName;
     let sopClassUIDMap = {};
     sopClassUIDMap[toUID.CTImage] = CTImageNormalizer;
-	sopClassUIDMap[toUID.ParametricMapStorage] = SEGImageNormalizer;
+    sopClassUIDMap[toUID.ParametricMapStorage] = PMImageNormalizer;
     sopClassUIDMap[toUID.MRImage] = MRImageNormalizer;
     sopClassUIDMap[toUID.EnhancedCTImage] = EnhancedCTImageNormalizer;
     sopClassUIDMap[toUID.LegacyConvertedEnhancedCTImage] = EnhancedCTImageNormalizer;
@@ -50373,6 +50373,7 @@ class Normalizer {
       toUID.EnhancedPETImage,
       toUID.LegacyConvertedEnhancedPETImage,
       toUID.Segmentation,
+      toUID.ParametricMapStorage,
     ];
     return (multiframeSOPClasses.indexOf(sopClassUID) !== -1);
   }
@@ -50757,6 +50758,16 @@ class PETImageNormalizer extends ImageNormalizer {
   }
 }
 
+class PMImageNormalizer extends ImageNormalizer{
+  normalize() {
+    super.normalize();
+    let ds = this.datasets[0]
+    if (ds.BitsAllocated !== 32) {
+      console.error('Only works with 32 bit data, not ' + String(ds.BitsAllocated));
+    }
+  }
+}
+
 class SEGImageNormalizer extends ImageNormalizer {
   normalize() {
     super.normalize();
@@ -50800,6 +50811,7 @@ let normalizers = {
   CTImageNormalizer,
   PETImageNormalizer,
   SEGImageNormalizer,
+  PMImageNormalizer,
   DSRNormalizer
 };
 

--- a/build/dcmjs.js
+++ b/build/dcmjs.js
@@ -1279,6 +1279,15 @@ class OtherByteString extends BinaryRepresentation {
     } */
 }
 
+class OtherFloatString extends BinaryRepresentation{
+     constructor(){
+        super("OF");
+        this.maxLength = null;
+        this.padByte = "00";
+        this.noMultiple = true;
+    }
+}
+
 class DicomMetaDictionary {
   static punctuateTag(rawTag) {
     if (rawTag.indexOf(',') !== -1) {
@@ -1537,6 +1546,7 @@ DicomMetaDictionary.sopClassNamesByUID = {
   "1.2.840.10008.5.1.4.1.1.6.1" : "USImage",
   "1.2.840.10008.5.1.4.1.1.6.2" : "EnhancedUSVolume",
   "1.2.840.10008.5.1.4.1.1.7" : "SecondaryCaptureImage",
+  "1.2.840.10008.5.1.4.1.1.30" : "ParametricMapStorage",
   "1.2.840.10008.5.1.4.1.1.66" : "RawData",
   "1.2.840.10008.5.1.4.1.1.66.1" : "SpatialRegistration",
   "1.2.840.10008.5.1.4.1.1.66.2" : "SpatialFiducials",
@@ -50336,6 +50346,7 @@ class Normalizer {
     let toUID = DicomMetaDictionary.sopClassUIDsByName;
     let sopClassUIDMap = {};
     sopClassUIDMap[toUID.CTImage] = CTImageNormalizer;
+	sopClassUIDMap[toUID.ParametricMapStorage] = SEGImageNormalizer;
     sopClassUIDMap[toUID.MRImage] = MRImageNormalizer;
     sopClassUIDMap[toUID.EnhancedCTImage] = EnhancedCTImageNormalizer;
     sopClassUIDMap[toUID.LegacyConvertedEnhancedCTImage] = EnhancedCTImageNormalizer;

--- a/examples/display2/index.html
+++ b/examples/display2/index.html
@@ -98,6 +98,7 @@
   // containers for managing background and segmentation data
   var dc0 = new DICOMZero({status});
   var dc0seg = new DICOMZero({status});
+  var dc0paraMap = new DICOMZero({status});
 
   $(document).ready(function() {
 
@@ -125,9 +126,17 @@
       if (dc0.viewer && evt.dataTransfer.files.length == 1) {
         dc0.handleDataTransferFileAsDataset(evt.dataTransfer.files[0], {
           doneCallback: function (dataset) {
+            console.log("callback "+dataset.SOPClassUID)
             if (dataset.SOPClassUID == DCMJS.data.DicomMetaDictionary.sopClassUIDsByName['Segmentation']) {
               dc0.viewer.addSegmentation(dataset);
               dc0seg.datasets = [dataset]
+              dc0.viewer.render();
+              setupControlPanel();
+            } else if (dataset.SOPClassUID == DCMJS.data.DicomMetaDictionary.sopClassUIDsByName['ParametricMapStorage']){
+              console.log("add call paramatric map to viewer...")
+              dc0.viewer.addParametricMap(dataset);
+              console.log("add call to viewer successfull")
+              dc0paraMap.datasets = [dataset]
               dc0.viewer.render();
               setupControlPanel();
             }

--- a/examples/display2/index.html
+++ b/examples/display2/index.html
@@ -52,6 +52,9 @@
         <label for="datasetSlider" class='datasetControl'>Frame: <span id="frameOffset">0</span></label>
         <input id="datasetSlider" class='datasetControl' type="range" min="0" max="0" value="0" steps="1" style="width: 512px"/>
         <div id='dicomImages'></div>
+        <div style="width:512px; padding-top: 5px;">
+          <canvas id="colorbar" width="512px" height="20px"></canvas>
+      </div>
       </div>
       <div class='col-md-4'>
         <h2>Controls</h2>
@@ -134,7 +137,7 @@
               setupControlPanel();
             } else if (dataset.SOPClassUID == DCMJS.data.DicomMetaDictionary.sopClassUIDsByName['ParametricMapStorage']){
               console.log("add call paramatric map to viewer...")
-              dc0.viewer.addParametricMap(dataset);
+              dc0.viewer.addParametricMap(dataset, "colorbar");
               console.log("add call to viewer successfull")
               dc0paraMap.datasets = [dataset]
               dc0.viewer.render();

--- a/examples/display2/index.html
+++ b/examples/display2/index.html
@@ -138,7 +138,7 @@
               console.log("add call to viewer successfull")
               dc0paraMap.datasets = [dataset]
               dc0.viewer.render();
-              setupControlPanel();
+              createControlPanel();
             }
           }
         });

--- a/examples/helpers/DICOMZero.js
+++ b/examples/helpers/DICOMZero.js
@@ -95,10 +95,13 @@ class DICOMZero {
   }
 
   datasetFromArrayBuffer(arrayBuffer) {
+    console.log("loading dicom data 1..")
     let dicomData = DCMJS.data.DicomMessage.readFile(arrayBuffer);
+    console.log("loading dicom data 2..")
     this.unnaturalDatasets.push(dicomData.dict);
     let dataset = DCMJS.data.DicomMetaDictionary.naturalizeDataset(dicomData.dict);
     dataset._meta = DCMJS.data.DicomMetaDictionary.namifyDataset(dicomData.meta);
+    console.log("loading dataset successfully")
     return(dataset);
   }
 

--- a/examples/helpers/DICOMZero.js
+++ b/examples/helpers/DICOMZero.js
@@ -95,9 +95,7 @@ class DICOMZero {
   }
 
   datasetFromArrayBuffer(arrayBuffer) {
-    console.log("loading dicom data 1..")
     let dicomData = DCMJS.data.DicomMessage.readFile(arrayBuffer);
-    console.log("loading dicom data 2..")
     this.unnaturalDatasets.push(dicomData.dict);
     let dataset = DCMJS.data.DicomMetaDictionary.naturalizeDataset(dicomData.dict);
     dataset._meta = DCMJS.data.DicomMetaDictionary.namifyDataset(dicomData.meta);

--- a/examples/helpers/viewer.js
+++ b/examples/helpers/viewer.js
@@ -411,11 +411,59 @@ class Viewer {
     // cornerstoneTools.addToolState(this.element, 'stack', multiframeStack);
   }
 
+  addParametricMap(paramatricMapDataset){
+    this.parametricMapDataset = paramatricMapDataset;
+
+    // TODO: colormap stuff
+          //
+      // then we create stack with an imageId and position metadata
+      // for each frame that references this segment number
+      //
+      let baseImageId = `dcmjsMultiframe${this.id}://`;
+      let imageIds = [];
+      let frameCount = Number(paramatricMapDataset.NumberOfFrames);
+      for (let frameIndex = 0; frameIndex < frameCount; frameIndex++) {
+        let perFrameGroup = paramatricMapDataset.PerFrameFunctionalGroupsSequence[frameIndex];
+        let referencedSegmentNumber;
+
+        const imageId = baseImageId + frameIndex;
+        imageIds.push(imageId);
+
+        let imagePositionPatient = perFrameGroup.PlanePositionSequence.ImagePositionPatient;
+        this.addMetaData('imagePlane', imageId, {
+          imagePositionPatient: {
+            x: imagePositionPatient[0],
+            y: imagePositionPatient[1],
+            z: imagePositionPatient[2],
+          }
+        });
+        
+      }
+
+      let parametricMapStack = {
+        imageIds: imageIds,
+        currentImageIdIndex: 0,
+        options: {
+          opacity: 0.7,
+          visible: true,
+          name: "parametricMap",
+          // viewport: {
+          //   pixelReplication: true,
+          //   colormap: colormapId,
+          //   labelmap: true
+          // }
+        }
+      }
+      // then add the stack to cornerstone
+      cornerstoneTools.addToolState(this.element, 'stack', parametricMapStack);
+  }
+
   //
   // make the set of stacks associated with segmentation segments
   // and add them to the stack tool
   //
   addSegmentation(segmentationDataset) {
+    console.log("sksldsd")
     this.segmentationDataset = segmentationDataset;
     let segmentSequence = this.segmentationDataset.SegmentSequence;
     if (!Array.isArray(segmentSequence)) {

--- a/examples/helpers/viewer.js
+++ b/examples/helpers/viewer.js
@@ -52,7 +52,6 @@ function convertToIntPixelData(floatPixelData){
     let rescaledPixel = 0
     if (floatPixelData[i] > 0){
       rescaledPixel = Math.floor((floatPixelData[i] - intercept) / slope);
-      count++;
     }
 
     intPixelData[i] = rescaledPixel;

--- a/examples/helpers/viewer.js
+++ b/examples/helpers/viewer.js
@@ -206,22 +206,24 @@ class Viewer {
       console.log("pixel data: "+this.parametricMapDataset.FloatPixelData[0].byteLength)
       let pixelData = new Float32Array(this.parametricMapDataset.FloatPixelData[0], frameOffset, frameBytes);
       let [min,max] = [Number.MAX_VALUE, Number.MIN_VALUE];
+      let nonZeroValues = []
       for (let pixelIndex = 0; pixelIndex < pixelData.length; pixelIndex++) {
+        if (pixelData[pixelIndex] > 0.0){
+          pixelData[pixelIndex] = Math.floor(pixelData[pixelIndex])*10;
+          nonZeroValues.push(pixelData[pixelIndex])
+        } else {
+          pixelData[pixelIndex] = 0;
+        }
         if (pixelData[pixelIndex] > max) { max = pixelData[pixelIndex]; }
         if (pixelData[pixelIndex] < min) { min = pixelData[pixelIndex]; }
       }
-      let [wc,ww] = [this.parametricMapDataset.WindowCenter,this.parametricMapDataset.WindowWidth];
-      if (Array.isArray(wc)) { wc = wc[0]; }
-      if (Array.isArray(ww)) { ww = ww[0]; }
+
+      console.log("nonzero values: "+nonZeroValues)
       let pixelMeasures = this.parametricMapDataset.SharedFunctionalGroupsSequence.PixelMeasuresSequence
       image = {
         imageId: imageId,
         minPixelValue: min,
         maxPixelValue: max,
-        slope: Number(this.parametricMapDataset.RescaleSlope || 1),
-        intercept: Number(this.parametricMapDataset.RescaleIntercept || 0),
-        windowCenter: Number(wc),
-        windowWidth: Number(ww),
         rows: Number(this.parametricMapDataset.Rows),
         columns: Number(this.parametricMapDataset.Columns),
         height: Number(this.parametricMapDataset.Rows),
@@ -230,12 +232,13 @@ class Viewer {
         rowPixelSpacing: Number(pixelMeasures.PixelSpacing[1]),
         invert: false,
         sizeInBytes: pixelData.byteLength,
-        getPixelData: function () { return(pixelData); },
+        labelmap: true,
+        getPixelData: function () { 
+          console.log("get pixel data: "+pixelData.length)
+          return(pixelData); },
       };
-      console.log("min: "+min)
-      console.log("max: "+max)
-      console.log("width: "+image.width)
-      console.log("spacingColumns: "+ image.columnPixelSpacing)
+      console.log("imageData: ")
+      console.log(image)
     }
 
     //
@@ -427,7 +430,7 @@ class Viewer {
       options: {
         name: 'Referenced Image',
         viewport: {
-          invert: invert
+          invert: invert,
         }
       }
     };
@@ -488,18 +491,20 @@ class Viewer {
     console.log("parametric map data set added")
     console.log(this.parametricMapDataset)
 
-    // TODO: colormap stuff
-    let rgba = [0, 250, 100, 255];
-    const colormapId = 'Colormap_PM';
+    //colormap stuff
+    const colormapId = 'hotIron';
     let colormap = cornerstone.colors.getColormap(colormapId);
-    let numberOfColors = 10/0.01
-    console.log(numberOfColors)
-    colormap.setNumberOfColors(numberOfColors);
-    colormap.insertColor(0, [0, 0, 0, 0]);
+    // let numberOfColors = 15
+
+    // colormap.setNumberOfColors(numberOfColors);
+
+    // for (let i = 1; i < numberOfColors; i++) {
+    //   var green = Math.round(i/Number(numberOfColors) * 255);
+    //   var rgba = [0, green, 0, 255];
   
-    for(var i = 0.1; i < 10; i=i+0.01){
-      colormap.insertColor(i, rgba);
-    }
+    //   colormap.insertColor(i, rgba);
+    // }
+    colormap.insertColor(0, [0, 0, 0, 0]);
 
     // then we create stack with an imageId and position metadata
     // for each frame that references this segment number
@@ -528,12 +533,12 @@ class Viewer {
       imageIds: imageIds,
       currentImageIdIndex: 0,
       options: {
-        opacity: 0.8,
+        opacity: 0.7,
         visible: true,
         name: "parametricMap",
         viewport: {
           pixelReplication: true,
-          colormap: colormapId,
+          colormap: "hotIron",
           labelmap: true
         }
       }

--- a/examples/helpers/viewer.js
+++ b/examples/helpers/viewer.js
@@ -478,12 +478,46 @@ class Viewer {
     // cornerstoneTools.addToolState(this.element, 'stack', multiframeStack);
   }
 
+
+  /**
+   * Updates the colorbar with the given colormap and the corresponding element id
+   * @param {*} colormap 
+   * @param {*} colorbarId 
+   */
+  updateColorbar(colormap, colorbarId) {
+    const lookupTable = colormap.createLookupTable();
+    const canvas = document.getElementById(colorbarId);
+    const ctx = canvas.getContext('2d');
+    const height = canvas.height;
+    const width = canvas.width;
+    const colorbar = ctx.createImageData(512, 20);
+
+    // Set the min and max values then the lookup table
+    // will be able to return the right color for this range
+    lookupTable.setTableRange(0, width);
+
+    // Update the colorbar pixel by pixel
+    for(let col = 0; col < width; col++) {
+        const color = lookupTable.mapValue(col);
+
+        for(let row = 0; row < height; row++) {
+            const pixel = (col + row * width) * 4;
+            colorbar.data[pixel] = color[0];
+            colorbar.data[pixel+1] = color[1];
+            colorbar.data[pixel+2] = color[2];
+            colorbar.data[pixel+3] = color[3];
+        }
+    }
+
+    ctx.putImageData(colorbar, 0, 0);
+  }
+
   /**
    * Adds a paramatric map object to this viewer instance.
    *
    * @param {dataset} paramatricMapDataset the data set which contains a multiframe dicom paramatric map object
    */
-  addParametricMap(paramatricMapDataset){
+  addParametricMap(paramatricMapDataset, colorbarId){
     this.parametricMapDataset = paramatricMapDataset;
 
     console.log(this.parametricMapDataset)
@@ -555,6 +589,8 @@ class Viewer {
     }
     // then add the stack to cornerstone
     cornerstoneTools.addToolState(this.element, 'stack', parametricMapStack);
+
+    this.updateColorbar(colormap, colorbarId)
   }
 
   //

--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -258,6 +258,7 @@ DicomMetaDictionary.sopClassNamesByUID = {
   "1.2.840.10008.5.1.4.1.1.6.1" : "USImage",
   "1.2.840.10008.5.1.4.1.1.6.2" : "EnhancedUSVolume",
   "1.2.840.10008.5.1.4.1.1.7" : "SecondaryCaptureImage",
+  "1.2.840.10008.5.1.4.1.1.30" : "ParametricMapStorage",
   "1.2.840.10008.5.1.4.1.1.66" : "RawData",
   "1.2.840.10008.5.1.4.1.1.66.1" : "SpatialRegistration",
   "1.2.840.10008.5.1.4.1.1.66.2" : "SpatialFiducials",

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -827,14 +827,14 @@ class OtherByteString extends BinaryRepresentation {
     } */
 }
 
-// class OtherFloatString extends BinaryRepresentation{
-//     constructor(){
-//         super("OF");
-//         this.maxLength = null;
-//         this.padByte = "00";
-//         this.noMultiple = true;
-//     }
-// }  
+class OtherFloatString extends BinaryRepresentation{
+    constructor(){
+        super("OF");
+        this.maxLength = null;
+        this.padByte = "00";
+        this.noMultiple = true;
+    }
+}  
 
 export { paddingLeft };
 export { tagFromNumbers };

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -821,12 +821,20 @@ class OtherByteString extends BinaryRepresentation {
         this.padByte = "00";
         this.noMultiple = true;
     }
-
     /*writeBytes(stream, value) {
         var written = super.write(stream, 'Hex', value);
         return super.writeBytes(stream, value, written);
     } */
 }
+
+// class OtherFloatString extends BinaryRepresentation{
+//     constructor(){
+//         super("OF");
+//         this.maxLength = null;
+//         this.padByte = "00";
+//         this.noMultiple = true;
+//     }
+// }  
 
 export { paddingLeft };
 export { tagFromNumbers };

--- a/src/normalizers.js
+++ b/src/normalizers.js
@@ -30,6 +30,7 @@ class Normalizer {
     let toUID = DicomMetaDictionary.sopClassUIDsByName;
     let sopClassUIDMap = {};
     sopClassUIDMap[toUID.CTImage] = CTImageNormalizer;
+    sopClassUIDMap[toUID.ParametricMapStorage] = SEGImageNormalizer;
     sopClassUIDMap[toUID.MRImage] = MRImageNormalizer;
     sopClassUIDMap[toUID.EnhancedCTImage] = EnhancedCTImageNormalizer;
     sopClassUIDMap[toUID.LegacyConvertedEnhancedCTImage] = EnhancedCTImageNormalizer;

--- a/src/normalizers.js
+++ b/src/normalizers.js
@@ -30,7 +30,7 @@ class Normalizer {
     let toUID = DicomMetaDictionary.sopClassUIDsByName;
     let sopClassUIDMap = {};
     sopClassUIDMap[toUID.CTImage] = CTImageNormalizer;
-    sopClassUIDMap[toUID.ParametricMapStorage] = SEGImageNormalizer;
+    sopClassUIDMap[toUID.ParametricMapStorage] = PMImageNormalizer;
     sopClassUIDMap[toUID.MRImage] = MRImageNormalizer;
     sopClassUIDMap[toUID.EnhancedCTImage] = EnhancedCTImageNormalizer;
     sopClassUIDMap[toUID.LegacyConvertedEnhancedCTImage] = EnhancedCTImageNormalizer;
@@ -57,6 +57,7 @@ class Normalizer {
       toUID.EnhancedPETImage,
       toUID.LegacyConvertedEnhancedPETImage,
       toUID.Segmentation,
+      toUID.ParametricMapStorage,
     ];
     return (multiframeSOPClasses.indexOf(sopClassUID) !== -1);
   }
@@ -447,6 +448,16 @@ class SEGImageNormalizer extends ImageNormalizer {
   }
 }
 
+class PMImageNormalizer extends ImageNormalizer{
+  normalize() {
+    super.normalize();
+    let ds = this.datasets[0]
+    if (ds.BitsAllocated !== 32) {
+      console.error('Only works with 32 bit data, not ' + String(ds.BitsAllocated));
+    }
+  }
+}
+
 class DSRNormalizer extends Normalizer {
   normalize() {
     this.dataset = this.datasets[0]; // only one dataset per series and for now we assume it is normalized
@@ -462,4 +473,5 @@ export { EnhancedUSVolumeNormalizer };
 export { CTImageNormalizer };
 export { PETImageNormalizer };
 export { SEGImageNormalizer };
+export { PMImageNormalizer };
 export { DSRNormalizer };


### PR DESCRIPTION
Adding paramtric map support to the viewer.js and enable display2-example to overlay a parametric map over a dicom image series.

Overlay-data is represented by a array-buffer conversion from originally 32bit float to 8bit unsigned int. This conversion is done while the values are rescaled from the previous range to 0 - 255 which makes a colormap integration easy. The example is using a colormap and visual colorbar.

![image](https://user-images.githubusercontent.com/19914448/44592773-d93d4c80-a7c1-11e8-9706-434c33cedd32.png)

public example data: https://drive.google.com/drive/folders/1Yfy0c1dvE7lp4jf99hhZwXDM74Cnc3r4?usp=sharing